### PR TITLE
FIX: ubuntu 18_04 should not use tensorflow

### DIFF
--- a/Dockerfile/ubuntu_18_04
+++ b/Dockerfile/ubuntu_18_04
@@ -1,4 +1,5 @@
-FROM tensorflow/tensorflow:1.14.0-gpu-py3 as tensorflow-image
+ARG UBUNTU_VERSION=18.04
+FROM ubuntu:${UBUNTU_VERSION}
 
 RUN mkdir -p /root/.cache/pip/wheels && \
     cd /root/.cache/pip/wheels && \


### PR DESCRIPTION
Verified this isn't used in customv2 and seems to be breaking our original gpu images