### PR TITLE
FIX: deal with extras having existing brackets

### DIFF
--- a/bin/install_github_dependencies
+++ b/bin/install_github_dependencies
@@ -20,6 +20,7 @@ fi
 if [ -z $extras ]; then
     pip3 install --find-links=/root/.cache/pip/wheels -e .
 else
+    extras=$(echo $extras | sed 's/[][]//g')
     pip3 install --find-links=/root/.cache/pip/wheels -e .[$extras]
 fi
 

--- a/bin/update_github_dependencies
+++ b/bin/update_github_dependencies
@@ -1,4 +1,3 @@
-
 #! /bin/bash
 
 package=${1}
@@ -17,6 +16,7 @@ else
     if [ -z $extras ]; then
         pip3 install --find-links=/root/.cache/pip/wheels -e .
     else
+        extras=$(echo $extras | sed 's/[][]//g')
         pip3 install --find-links=/root/.cache/pip/wheels -e .[$extras]
     fi
 fi


### PR DESCRIPTION
Wanna be able to pass along `EXTRAS=['test']` the way we do for the main packages