### PR TITLE
[DEV-6759] ADD:opentracing and lightstep tracer

### DIFF
--- a/Dockerfile/nginx-uploader
+++ b/Dockerfile/nginx-uploader
@@ -39,8 +39,10 @@ RUN export NGINX_RAW_VERSION=$(echo $NGINX_VERSION | sed 's/-.*//g') \
 
 # Install opentracing
 RUN apt-get install wget
-RUN cd /modules && wget -O - https://github.com/opentracing-contrib/nginx-opentracing/releases/download/v0.15.0/linux-amd64-nginx-1.19.4-ngx_http_module.so.tgz | tar -zxf - \
-    && wget -O - https://github.com/lightstep/lightstep-tracer-cpp/releases/download/v0.13.0/linux-amd64-liblightstep_tracer_plugin.so.gz | gunzip -c > /modules/liblightstep_tracer_plugin.so
+RUN cd /modules && wget -O - https://github.com/opentracing-contrib/nginx-opentracing/releases/download/v0.11.0/linux-amd64-nginx-1.19.4-ngx_http_module.so.tgz | tar -zxf - \
+    && wget -O - https://github.com/lightstep/lightstep-tracer-cpp/releases/download/v0.9.0/linux-amd64-liblightstep_tracer_plugin.so.gz | gunzip -c > /usr/local/lib/liblightstep_tracer_plugin.so
+
+# was 0.8.1 version
 
 FROM nginx:${nginx_version}
 
@@ -59,6 +61,7 @@ RUN apt update && \
 RUN apt clean && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /modules/* /usr/lib/nginx/modules/
+COPY --from=build /usr/local/lib/liblightstep_tracer_plugin.so /usr/local/lib/liblightstep_tracer_plugin.so
 COPY --from=build /usr/local/modsecurity/ /usr/local/modsecurity/
 
 RUN rm -f /etc/nginx/modules/all.conf \

--- a/Dockerfile/nginx-uploader
+++ b/Dockerfile/nginx-uploader
@@ -38,8 +38,9 @@ RUN export NGINX_RAW_VERSION=$(echo $NGINX_VERSION | sed 's/-.*//g') \
     && cp $(pwd)/objs/*.so /modules
 
 # Install opentracing
-cd /modules && wget -O - https://github.com/opentracing-contrib/nginx-opentracing/releases/download/v0.16.0/linux-amd64-nginx-${nginx_version}-ngx_http_module.so.tgz | tar zxf -
-wget -O - https://github.com/lightstep/lightstep-tracer-cpp/releases/download/v0.8.1/linux-amd64-liblightstep_tracer_plugin.so.gz | gunzip -c > /usr/local/lib/liblightstep_tracer_plugin.so
+RUN apt-get install wget
+RUN cd /modules && wget -O - https://github.com/opentracing-contrib/nginx-opentracing/releases/download/v0.15.0/linux-amd64-nginx-1.19.4-ngx_http_module.so.tgz | tar -zxf - \
+    && wget -O - https://github.com/lightstep/lightstep-tracer-cpp/releases/download/v0.13.0/linux-amd64-liblightstep_tracer_plugin.so.gz | gunzip -c > /modules/liblightstep_tracer_plugin.so
 
 FROM nginx:${nginx_version}
 
@@ -59,7 +60,6 @@ RUN apt clean && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /modules/* /usr/lib/nginx/modules/
 COPY --from=build /usr/local/modsecurity/ /usr/local/modsecurity/
-COPY --from=build /usr/local/lib/liblightstep_tracer_plugin.so /usr/local/lib/liblightstep_tracer_plugin.so
 
 RUN rm -f /etc/nginx/modules/all.conf \
     && ls /etc/nginx/modules/*.so | grep -v debug | xargs -I{} sh -c 'echo "load_module {};" | tee -a  /etc/nginx/modules/all.conf'

--- a/Dockerfile/nginx-uploader
+++ b/Dockerfile/nginx-uploader
@@ -42,8 +42,6 @@ RUN apt-get install wget
 RUN cd /modules && wget -O - https://github.com/opentracing-contrib/nginx-opentracing/releases/download/v0.11.0/linux-amd64-nginx-1.19.4-ngx_http_module.so.tgz | tar -zxf - \
     && wget -O - https://github.com/lightstep/lightstep-tracer-cpp/releases/download/v0.9.0/linux-amd64-liblightstep_tracer_plugin.so.gz | gunzip -c > /usr/local/lib/liblightstep_tracer_plugin.so
 
-# was 0.8.1 version
-
 FROM nginx:${nginx_version}
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/Dockerfile/nginx-uploader
+++ b/Dockerfile/nginx-uploader
@@ -37,6 +37,10 @@ RUN export NGINX_RAW_VERSION=$(echo $NGINX_VERSION | sed 's/-.*//g') \
     && mkdir /modules \
     && cp $(pwd)/objs/*.so /modules
 
+# Install opentracing
+cd /modules && wget -O - https://github.com/opentracing-contrib/nginx-opentracing/releases/download/v0.16.0/linux-amd64-nginx-${nginx_version}-ngx_http_module.so.tgz | tar zxf -
+wget -O - https://github.com/lightstep/lightstep-tracer-cpp/releases/download/v0.8.1/linux-amd64-liblightstep_tracer_plugin.so.gz | gunzip -c > /usr/local/lib/liblightstep_tracer_plugin.so
+
 FROM nginx:${nginx_version}
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -55,6 +59,7 @@ RUN apt clean && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /modules/* /usr/lib/nginx/modules/
 COPY --from=build /usr/local/modsecurity/ /usr/local/modsecurity/
+COPY --from=build /usr/local/lib/liblightstep_tracer_plugin.so /usr/local/lib/liblightstep_tracer_plugin.so
 
 RUN rm -f /etc/nginx/modules/all.conf \
     && ls /etc/nginx/modules/*.so | grep -v debug | xargs -I{} sh -c 'echo "load_module {};" | tee -a  /etc/nginx/modules/all.conf'

--- a/Dockerfile/nginx-uploader
+++ b/Dockerfile/nginx-uploader
@@ -38,8 +38,8 @@ RUN export NGINX_RAW_VERSION=$(echo $NGINX_VERSION | sed 's/-.*//g') \
     && cp $(pwd)/objs/*.so /modules
 
 # Install opentracing
-RUN apt-get install wget
-RUN cd /modules && wget -O - https://github.com/opentracing-contrib/nginx-opentracing/releases/download/v0.11.0/linux-amd64-nginx-1.19.4-ngx_http_module.so.tgz | tar -zxf - \
+RUN apt-get install wget \
+    && cd /modules && wget -O - https://github.com/opentracing-contrib/nginx-opentracing/releases/download/v0.11.0/linux-amd64-nginx-1.19.4-ngx_http_module.so.tgz | tar -zxf - \
     && wget -O - https://github.com/lightstep/lightstep-tracer-cpp/releases/download/v0.9.0/linux-amd64-liblightstep_tracer_plugin.so.gz | gunzip -c > /usr/local/lib/liblightstep_tracer_plugin.so
 
 FROM nginx:${nginx_version}


### PR DESCRIPTION
- Added the nginx-opentracing plugin to the existing modules location
- The lightstep tracer is not a module but a dynamic loaded plugin. Was not able to get this work if it saved in the location existing modules are saved but works with if saved in /usr/local/lib