### PR TITLE
Support subpackage install

### DIFF
--- a/bin/install_github_dependencies
+++ b/bin/install_github_dependencies
@@ -5,8 +5,10 @@ package=${1}
 extras=${2}
 commit=${3}
 
+IFS='/'; repo=($package); unset IFS;
+
 cd /
-git clone https://${GITHUB_ACCESS_TOKEN}@github.com/IndicoDataSolutions/${package}.git
+git clone https://${GITHUB_ACCESS_TOKEN}@github.com/IndicoDataSolutions/${repo}.git
 cd ${package}
 
 if [ ! -z $commit ]; then


### PR DESCRIPTION
This should help if we want to use only a portion of a github package as a dependency in another project.

I think we just need to separate the subpackage out under its own path in the project and add `setup.py`.