### PR TITLE
[DEV-6817]: Bump git in alpine image

### DIFF
--- a/Dockerfile/alpine
+++ b/Dockerfile/alpine
@@ -8,7 +8,7 @@ RUN mkdir -p /root/.cache/pip/wheels && \
         build-base \
         python3-dev \
         python3 \
-        git \
+        git>2.15.4 \
         coreutils \
         bash \
         curl \


### PR DESCRIPTION
Bump git to resolve git vuln.

Currently corresponds to alpine:vulns but once merged will delete vuln tag and change to alpine:latest.