### PR TITLE
[DEV-6725]: Bump alpine in flower image

### DIFF
--- a/Dockerfile/flower
+++ b/Dockerfile/flower
@@ -1,4 +1,4 @@
-FROM gcr.io/new-indico/alpine:3.9.3
+FROM gcr.io/new-indico/alpine:vulns
 
 EXPOSE 5555
 


### PR DESCRIPTION
Bumps alpine tag in flower to remedy git vuln from Alpine. Once alpine image pr is merged this pr will be updated with latest tag.