### PR TITLE
[DEV-6820]: Add numpy 1.20.3 image

### DIFF
--- a/Dockerfile/numpy-ubuntu
+++ b/Dockerfile/numpy-ubuntu
@@ -1,6 +1,5 @@
 FROM gcr.io/new-indico/ubuntu:18.04
 
-ARG NUMPY_VERSION=1.15.4
+ARG NUMPY_VERSION=1.20.3
 
 RUN pip3 wheel numpy==${NUMPY_VERSION}
-

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -58,6 +58,14 @@ numpy-ubuntu-1.18.4:
     dockerfile: Dockerfile/numpy-ubuntu
   dockercfg_service: gcr-dockercfg
 
+numpy-ubuntu-1.20.3:
+  default_cache_branch: "latest"
+  build:
+    args:
+      NUMPY_VERSION: 1.20.3
+    dockerfile: Dockerfile/numpy-ubuntu
+  dockercfg_service: gcr-dockercfg
+
 nvidia-install:
   default_cache_branch: "latest"
   build:

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -87,6 +87,14 @@
           image_tag: "1.18.4"
           dockercfg_service: gcr-dockercfg
 
+        - name: numpy-ubuntu-1.20.3
+          type: push
+          service: numpy-ubuntu-1.20.3
+          registry: https://gcr.io
+          image_name: gcr.io/new-indico/numpy-ubuntu
+          image_tag: "1.20.3"
+          dockercfg_service: gcr-dockercfg
+
         - name: aws
           type: push
           service: aws


### PR DESCRIPTION
Add new image for numpy 1.20.3. Can overwrite latest with this version if preferred?