### PR TITLE
[DEV-6709]: pandas 1.2.4 image

### DIFF
--- a/Dockerfile/pandas-ubuntu
+++ b/Dockerfile/pandas-ubuntu
@@ -1,10 +1,10 @@
-ARG NUMPY_VERSION=1.15.4
+ARG NUMPY_VERSION=1.20.3
 FROM gcr.io/new-indico/numpy-ubuntu:${NUMPY_VERSION} as numpy-base
 
 FROM gcr.io/new-indico/ubuntu:18.04
 
 COPY --from=numpy-base /root/.cache/pip/wheels/ /root/.cache/pip/wheels
-ARG PANDAS_VERSION=0.23.4
+ARG PANDAS_VERSION=1.2.4
 ARG NUMPY_VERSION
 
 RUN pip3 install cython && \

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -87,6 +87,15 @@ pandas-ubuntu-1.0.3:
       NUMPY_VERSION: 1.18.4
   dockercfg_service: gcr-dockercfg
 
+pandas-ubuntu-1.2.4:
+  default_cache_branch: "latest"
+  build:
+    dockerfile: Dockerfile/pandas-ubuntu
+    args:
+      PANDAS_VERSION: 1.2.4
+      NUMPY_VERSION: 1.20.3
+  dockercfg_service: gcr-dockercfg
+
 rocksdb:
   default_cache_branch: "latest"
   build:

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -72,21 +72,6 @@ nvidia-install:
     dockerfile: Dockerfile/nvidia-install
   dockercfg_service: gcr-dockercfg
 
-pandas-ubuntu:
-  default_cache_branch: "latest"
-  build:
-    dockerfile: Dockerfile/pandas-ubuntu
-  dockercfg_service: gcr-dockercfg
-
-pandas-ubuntu-1.0.3:
-  default_cache_branch: "latest"
-  build:
-    dockerfile: Dockerfile/pandas-ubuntu
-    args:
-      PANDAS_VERSION: 1.0.3
-      NUMPY_VERSION: 1.18.4
-  dockercfg_service: gcr-dockercfg
-
 pandas-ubuntu-1.2.4:
   default_cache_branch: "latest"
   build:
@@ -173,8 +158,7 @@ test-2:
 test-3:
   image: busybox
   depends_on:
-    - pandas-ubuntu
-    - pandas-ubuntu-1.0.3
+    - pandas-ubuntu-1.2.4
     - scipy-ubuntu
 
 test-4:

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -270,6 +270,11 @@
       command: sh -c 'sh scan-images.sh pandas-ubuntu-1.0.3-anchorestep gcr.io/new-indico/pandas-ubuntu:1.0.3'
       encrypted_env_file: env.encrypted
 
+    - name: pandas-ubuntu-1.2.4-anchorestep
+      service: anchorescan
+      command: sh -c 'sh scan-images.sh pandas-ubuntu-1.2.4-anchorestep gcr.io/new-indico/pandas-ubuntu:1.2.4'
+      encrypted_env_file: env.encrypted
+
     - name: tsne-ubuntu-anchorestep
       service: anchorescan
       command: sh -c 'sh scan-images.sh tsne-ubuntu-anchorestep gcr.io/new-indico/tsne-ubuntu:latest'

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -145,22 +145,6 @@
           image_tag: "1.1.0"
           dockercfg_service: gcr-dockercfg
 
-        - name: pandas-ubuntu
-          type: push
-          service: pandas-ubuntu
-          registry: https://gcr.io
-          image_name: gcr.io/new-indico/pandas-ubuntu
-          image_tag: "0.23.4"
-          dockercfg_service: gcr-dockercfg
-
-        - name: pandas-ubuntu-1.0.3
-          type: push
-          service: pandas-ubuntu-1.0.3
-          registry: https://gcr.io
-          image_name: gcr.io/new-indico/pandas-ubuntu
-          image_tag: "1.0.3"
-          dockercfg_service: gcr-dockercfg
-
         - name: pandas-ubuntu-1.2.4
           type: push
           service: pandas-ubuntu-1.2.4
@@ -258,16 +242,6 @@
     - name: scipy-ubuntu-anchorestep
       service: anchorescan
       command: sh -c 'sh scan-images.sh scipy-ubuntu-anchorestep gcr.io/new-indico/scipy-ubuntu:1.1.0'
-      encrypted_env_file: env.encrypted
-
-    - name: pandas-ubuntu-anchorestep
-      service: anchorescan
-      command: sh -c 'sh scan-images.sh pandas-ubuntu-anchorestep gcr.io/new-indico/pandas-ubuntu:0.23.4'
-      encrypted_env_file: env.encrypted
-
-    - name: pandas-ubuntu-1.0.3-anchorestep
-      service: anchorescan
-      command: sh -c 'sh scan-images.sh pandas-ubuntu-1.0.3-anchorestep gcr.io/new-indico/pandas-ubuntu:1.0.3'
       encrypted_env_file: env.encrypted
 
     - name: pandas-ubuntu-1.2.4-anchorestep

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -161,6 +161,14 @@
           image_tag: "1.0.3"
           dockercfg_service: gcr-dockercfg
 
+        - name: pandas-ubuntu-1.2.4
+          type: push
+          service: pandas-ubuntu-1.2.4
+          registry: https://gcr.io
+          image_name: gcr.io/new-indico/pandas-ubuntu
+          image_tag: "1.2.4"
+          dockercfg_service: gcr-dockercfg
+
     - type: parallel
       steps:
         - name: tsne-ubuntu


### PR DESCRIPTION
Pandas 1.0.3 contains vulnerabilities and so fixing image with 1.0.3 tag doesn't make sense. Instead, bumped pandas (1.2.4) and version and numpy image (numpy-ubuntu:1.20.3) and created new tag, 1.2.4