### PR TITLE
[DEV-6716]: Docker Vulnerability Remediation connect

### DIFF
--- a/Dockerfile/connect
+++ b/Dockerfile/connect
@@ -1,6 +1,11 @@
-FROM confluentinc/cp-kafka-connect:5.5.0 as cp
-FROM debezium/connect:1.3 as debezium
-FROM strimzi/kafka:0.20.0-kafka-2.5.0
+ARG CP_KAFKA_CONNECT_VERSION=5.5.5
+ARG CONNECT_VERSION=1.6
+ARG KAFKA_VERSION=0.20.1-kafka-2.6.0
+
+FROM confluentinc/cp-kafka-connect:${CP_KAFKA_CONNECT_VERSION} as cp
+FROM debezium/connect:${CONNECT_VERSION} as debezium
+FROM strimzi/kafka:${KAFKA_VERSION}
+
 USER root:root
 COPY --from=cp /usr/share/java/kafka-connect-storage-common /opt/kafka/plugins/kafka-connect-storage-common
 COPY --from=cp /usr/share/java/confluent-common /opt/kafka/plugins/confluent-common


### PR DESCRIPTION
Bumps the following base images:

confluentinc/cp-kafka-connect:5.5.0 -> 5.5.5 (any higher and it complains of a missing dir)
debezium/connect:1.3 -> 1.6
strimzi/kafka:0.20.0-kafka-2.5.0 -> 0.20.1-kafka-2.6.0