### PR TITLE
Update ubuntu tag in numpy image

### DIFF
--- a/Dockerfile/numpy-ubuntu
+++ b/Dockerfile/numpy-ubuntu
@@ -1,4 +1,4 @@
-FROM gcr.io/new-indico/ubuntu:18.04
+FROM gcr.io/new-indico/ubuntu:bionic
 
 ARG NUMPY_VERSION=1.20.3
 


### PR DESCRIPTION
There was a recently discovered vulnerability in ubuntu 18.04, including bionic-20210512. It has been fixed in ubuntu using the plain bionic tag. Other services I was working on that were in progress when I noticed this new vulnerability have been updated. Ones that had already been updated per the vulnerability project will be re-updated under ticket [DEV-6957](https://indicodata.atlassian.net/browse/DEV-6957)