### PR TITLE
[DEV-6742]: Docker Vulnerability Remediation strimzi-kafka

### DIFF
--- a/scripts/build_and_push_strimzi_kafka.sh
+++ b/scripts/build_and_push_strimzi_kafka.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+TAG=0.20.1-kafka-2.6.0
+
+docker pull strimzi/kafka:$TAG
+docker tag strimzi/kafka:$TAG gcr.io/new-indico/strimzi-kafka:$TAG
+docker push gcr.io/new-indico/strimzi-kafka:$TAG


### PR DESCRIPTION
Adds script to manually build and push strimzi-kafka image. Adds 0.20.1-kafka-2.6.0 (tag in use is 0.20.0-kafka-2.6.0)