### PR TITLE
[DEV-6717]: Docker Vulnerability Remediation cp-schema-registry

### DIFF
--- a/scripts/build_and_push_cp_schema_registry.sh
+++ b/scripts/build_and_push_cp_schema_registry.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+TAG=5.5.5
+
+docker pull confluentinc/cp-schema-registry:$TAG
+docker tag confluentinc/cp-schema-registry:$TAG gcr.io/new-indico/cp-schema-registry:$TAG
+docker push gcr.io/new-indico/cp-schema-registry:$TAG


### PR DESCRIPTION
Adds script to manually build and push cp-schema-registy image. Adds 5.5.5 (tag in use is 5.5.0)