### PR TITLE
Add indico-tensorflow image

### DIFF
--- a/Dockerfile/indico-tensorflow
+++ b/Dockerfile/indico-tensorflow
@@ -1,0 +1,136 @@
+ARG UBUNTU_VERSION=18.04
+ARG TENSORFLOW_GPU_VERSION=2.3.3
+
+ARG ARCH=
+ARG CUDA=10.1
+FROM nvidia/cuda${ARCH:+-$ARCH}:${CUDA}-base-ubuntu${UBUNTU_VERSION} as base
+# ARCH and CUDA are specified again because the FROM directive resets ARGs
+# (but their default value is retained if set previously)
+ARG ARCH
+ARG CUDA
+ARG CUDNN=7.6.4.38-1
+ARG CUDNN_MAJOR_VERSION=7
+ARG LIB_DIR_PREFIX=x86_64
+ARG LIBNVINFER=6.0.1-1
+ARG LIBNVINFER_MAJOR_VERSION=6
+
+# Needed for string substitution
+SHELL ["/bin/bash", "-c"]
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        cuda-command-line-tools-${CUDA/./-} \
+        # There appears to be a regression in libcublas10=10.2.2.89-1 which
+        # prevents cublas from initializing in TF. See
+        # https://github.com/tensorflow/tensorflow/issues/9489#issuecomment-562394257
+        libcublas10=10.2.1.243-1 \
+        libcublas-dev=10.2.1.243-1 \
+        cuda-nvrtc-${CUDA/./-} \
+        cuda-nvrtc-dev-${CUDA/./-} \
+        cuda-cudart-dev-${CUDA/./-} \
+        cuda-cufft-dev-${CUDA/./-} \
+        cuda-curand-dev-${CUDA/./-} \
+        cuda-cusolver-dev-${CUDA/./-} \
+        cuda-cusparse-dev-${CUDA/./-} \
+        libcudnn7=${CUDNN}+cuda${CUDA} \
+        libcudnn7-dev=${CUDNN}+cuda${CUDA} \
+        libcurl3-dev \
+        libfreetype6-dev \
+        libhdf5-serial-dev \
+        libzmq3-dev \
+        pkg-config \
+        rsync \
+        software-properties-common \
+        unzip \
+        zip \
+        zlib1g-dev \
+        wget \
+        git \
+        && \
+    find /usr/local/cuda-${CUDA}/lib64/ -type f -name 'lib*_static.a' -not -name 'libcudart_static.a' -delete && \
+    rm /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libcudnn_static_v7.a
+
+# Install TensorRT if not building for PowerPC
+RUN [[ "${ARCH}" = "ppc64le" ]] || { apt-get update && \
+        apt-get install -y --no-install-recommends libnvinfer${LIBNVINFER_MAJOR_VERSION}=${LIBNVINFER}+cuda${CUDA} \
+        libnvinfer-dev=${LIBNVINFER}+cuda${CUDA} \
+        libnvinfer-plugin-dev=${LIBNVINFER}+cuda${CUDA} \
+        libnvinfer-plugin${LIBNVINFER_MAJOR_VERSION}=${LIBNVINFER}+cuda${CUDA} \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*; }
+
+# Configure the build for our CUDA configuration.
+ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs:/usr/include/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
+ENV TF_NEED_CUDA 1
+ENV TF_NEED_TENSORRT 1
+ENV TF_CUDA_VERSION=${CUDA}
+ENV TF_CUDNN_VERSION=${CUDNN_MAJOR_VERSION}
+# CACHE_STOP is used to rerun future commands, otherwise cloning tensorflow will be cached and will not pull the most recent version
+ARG CACHE_STOP=1
+# Check out TensorFlow source code if --build-arg CHECKOUT_TF_SRC=1
+ARG CHECKOUT_TF_SRC=0
+RUN test "${CHECKOUT_TF_SRC}" -eq 1 && git clone https://github.com/tensorflow/tensorflow.git /tensorflow_src || true
+
+# Link the libcuda stub to the location where tensorflow is searching for it and reconfigure
+# dynamic linker run-time bindings
+RUN ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 \
+    && echo "/usr/local/cuda/lib64/stubs" > /etc/ld.so.conf.d/z-cuda-stubs.conf \
+    && ldconfig
+
+# See http://bugs.python.org/issue19846
+ENV LANG C.UTF-8
+
+RUN apt-get update && apt-get install -y \
+    python3.7 \
+    python3-pip
+
+RUN ln -s $(which python3.7) /usr/local/bin/python
+RUN ln -s $(which python3.7) /usr/local/bin/python3
+RUN alias pip3='pip3.7'
+
+RUN python3.7 -m pip --no-cache-dir install --upgrade \
+    pip \
+    setuptools
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    git \
+    wget \
+    openjdk-8-jdk \
+    python3.7-dev \
+    virtualenv \
+    swig
+
+RUN python3.7 -m pip --no-cache-dir install \
+    Pillow \
+    h5py \
+    keras_preprocessing \
+    matplotlib \
+    mock \
+    numpy \
+    scipy \
+    sklearn \
+    pandas \
+    future \
+    portpicker \
+    enum34
+
+# Install tensorflow
+# COPY bashrc /etc/bash.bashrc
+RUN chmod a+rwx /etc/bash.bashrc
+
+ARG TENSORFLOW_GPU_VERSION
+RUN python3.7 -m pip install tensorflow-gpu==${TENSORFLOW_GPU_VERSION}
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/lib
+
+RUN python3.7 -m pip install --no-cache-dir matplotlib
+RUN apt-get install wget
+RUN apt-get autoremove -y && apt-get remove -y wget
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/lib:/usr/local/nvidia/lib64
+
+WORKDIR /tf
+EXPOSE 8888
+
+COPY ./bin /usr/bin
+
+CMD ["sleep", "infinity"]

--- a/Dockerfile/indico-tensorflow
+++ b/Dockerfile/indico-tensorflow
@@ -101,20 +101,6 @@ RUN apt-get update && apt-get install -y \
     virtualenv \
     swig
 
-RUN python3.7 -m pip --no-cache-dir install \
-    Pillow \
-    h5py \
-    keras_preprocessing \
-    matplotlib \
-    mock \
-    numpy \
-    scipy \
-    sklearn \
-    pandas \
-    future \
-    portpicker \
-    enum34
-
 # Install tensorflow
 RUN chmod a+rwx /etc/bash.bashrc
 

--- a/Dockerfile/indico-tensorflow
+++ b/Dockerfile/indico-tensorflow
@@ -116,7 +116,6 @@ RUN python3.7 -m pip --no-cache-dir install \
     enum34
 
 # Install tensorflow
-# COPY bashrc /etc/bash.bashrc
 RUN chmod a+rwx /etc/bash.bashrc
 
 ARG TENSORFLOW_GPU_VERSION


### PR DESCRIPTION
Adds indico-tensorflow image to repo. Current image uses tensorflow 2.3.3-gpu.

Changes compared to what @benleetownsend shared:

- adds tensorflow-gpu version arg (currently set to 2.3.3)
- removes <1.19.0 numpy version constraint
- removes `COPY bashrc /etc/bash.bashrc` under "# Install tensorflow section"